### PR TITLE
CI Checklist: Adding Checklist Workflow For Tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+<!-- What does this PR change at a high level? -->
+
+## Motivation
+<!-- Why is this change needed? What problem does it solve? -->
+
+## Key changes
+<!-- Bullet list of the most important changes -->
+- 
+-
+-
+
+## Architectural notes (if applicable)
+<!-- Any ownership changes, invariants, or mental-model shifts -->
+
+## Follow-ups
+<!-- Things intentionally left out or planned next steps -->
+- 
+
+## Checklist
+- [ ] Builds and runs locally
+- [ ] No new warnings
+- [ ] Naming and ownership make sense
+- [ ] Has tests

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,0 +1,21 @@
+name: Checklist
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  checklist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for "Has tests" checkbox
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || "";
+            const required = "- [x] Has tests";
+            if (!body.includes(required)) {
+              core.setFailed(
+                'PR must check "- [x] Has tests" in the checklist.'
+              );
+            }


### PR DESCRIPTION
## Summary
Adding a default PR template and a workflow for checking a `Has tests` checkbox.

## Motivation
Want to include a sanity check for tests in PR's.

## Key changes
<!-- Bullet list of the most important changes -->
- Added `pull_request_template` for PR's.
- Added `checklist` workflow for checking the `Has tests` checkbox is ticked.

## Architectural notes (if applicable)
<!-- Any ownership changes, invariants, or mental-model shifts -->
N/A

## Follow-ups
<!-- Things intentionally left out or planned next steps -->
N/A

## Checklist
- [ ] Builds and runs locally
- [ ] No new warnings
- [ ] Naming and ownership make sense
- [x] Has tests