### PR TITLE
Render Architecture: Abstracting Shaders and Refactor

### DIFF
--- a/src/engine/render/buffers/buffer.h
+++ b/src/engine/render/buffers/buffer.h
@@ -9,6 +9,7 @@
 
 struct Drawable;
 struct MeshInstance;
+
 struct BufferConfig {
 	size_t size;
 	SDL_GPUBufferUsageFlags usage;
@@ -19,17 +20,7 @@ struct TransferBufferConfig {
 	SDL_GPUTransferBufferUsage usage;
 };
 
-enum class BufferType {
-	Vertex,
-	Index,
-	Uniform,
-	TransferUpload,
-	TransferDownload
-};
-
 struct CPUBuffer {
-	BufferType type;
-
 	SDL_GPUTransferBuffer* buffer = nullptr;
 
 	bool mapped = false;
@@ -37,8 +28,6 @@ struct CPUBuffer {
 };
 
 struct GPUBuffer {
-	BufferType type;
-
 	SDL_GPUBuffer* buffer = nullptr;
 };
 

--- a/src/engine/render/material.h
+++ b/src/engine/render/material.h
@@ -7,7 +7,8 @@
 #include <string>
 
 struct MaterialState {
-	std::string shader;
+	std::string vertex_shader;
+	std::string fragment_shader;
 	SDL_GPUPrimitiveType primitive_type;
 	SDL_GPUCullMode cull_mode;
 	SDL_GPUCompareOp compare_op;
@@ -15,7 +16,9 @@ struct MaterialState {
 	bool enable_depth_write;
 
 	bool operator== (const MaterialState& other) const {
-		return shader == other.shader && primitive_type == other.primitive_type
+		return vertex_shader == other.vertex_shader
+			   && fragment_shader == other.fragment_shader
+			   && primitive_type == other.primitive_type
 			   && cull_mode == other.cull_mode && compare_op
 			   && enable_depth_test == other.enable_depth_test
 			   && enable_depth_write == other.enable_depth_write
@@ -33,7 +36,8 @@ template <> struct std::hash<MaterialState> {
 	size_t operator() (const MaterialState& material) const noexcept {
 		size_t h = 0;
 
-		hash_combine (h, std::hash<std::string> () (material.shader));
+		hash_combine (h, std::hash<std::string> () (material.vertex_shader));
+		hash_combine (h, std::hash<std::string> () (material.fragment_shader));
 		hash_combine (h, std::hash<int> () (material.primitive_type));
 		hash_combine (h, std::hash<int> () (material.cull_mode));
 
@@ -52,7 +56,8 @@ namespace Materials {
 inline static MaterialInstance Geometry{
 	.name = "geometry",
 	.state
-	= {.shader = "geometry",
+	= {.vertex_shader = "geometry",
+	   .fragment_shader = "gbuffer",
 	   .primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
 	   .cull_mode = SDL_GPU_CULLMODE_BACK,
 	   .compare_op = SDL_GPU_COMPAREOP_LESS,
@@ -64,7 +69,8 @@ inline static MaterialInstance Geometry{
 inline static MaterialInstance Deferred{
 	.name = "deferred",
 	.state
-	= {.shader = "lighting",
+	= {.vertex_shader = "screen",
+	   .fragment_shader = "lighting",
 	   .primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
 	   .cull_mode = SDL_GPU_CULLMODE_BACK,
 	   .compare_op = SDL_GPU_COMPAREOP_LESS,

--- a/src/engine/render/pipelines/sdl/factory.h
+++ b/src/engine/render/pipelines/sdl/factory.h
@@ -5,6 +5,8 @@
 
 #include <SDL3/SDL.h>
 
+#include "render/shaders/shader.h"
+
 struct Pipeline;
 struct PipelineState;
 class ShaderManager;
@@ -17,6 +19,8 @@ class SDLPipelineFactory : public IPipelineFactory {
 	);
 	~SDLPipelineFactory () override;
 
+	SDL_GPUVertexInputRate to_sdl_input_rate (InputRate input_rate);
+	SDL_GPUVertexElementFormat to_sdl_vertex_format (DataTypes data_type);
 	Pipeline* create_pipeline (const PipelineState& pipeline_state) override;
 
   private:

--- a/src/engine/render/render.cpp
+++ b/src/engine/render/render.cpp
@@ -69,41 +69,44 @@ void RenderManager::load_shaders () const {
 		SDL_LOG_CATEGORY_RENDER, "Loading shaders.", shader_base.c_str ()
 	);
 
-	shader_manager->load_shader (
-		ShaderConfig{
-			.path = shader_base + "bin/geometry.vert.metallib",
-			.entrypoint = "main0",
-			.format = SDL_GPU_SHADERFORMAT_METALLIB,
-			.stage = SDL_GPU_SHADERSTAGE_VERTEX,
-			.num_uniform_buffers = 1
-		},
-		ShaderConfig{
-			.path = shader_base + "bin/gbuffer.frag.metallib",
-			.entrypoint = "main0",
-			.format = SDL_GPU_SHADERFORMAT_METALLIB,
-			.stage = SDL_GPU_SHADERSTAGE_FRAGMENT,
-			.num_uniform_buffers = 1
-		},
-		"geometry"
-	);
+	auto geometry_vertex_shader = Shader{
+		.name = "geometry",
+		.path = shader_base + "bin/geometry.vert.metallib",
+		.entrypoint = "main0",
+		.format = SDL_GPU_SHADERFORMAT_METALLIB,
+		.stage = SDL_GPU_SHADERSTAGE_VERTEX,
+	};
+
+	auto geometry_fragment_shader = Shader{
+		.name = "gbuffer",
+		.path = shader_base + "bin/gbuffer.frag.metallib",
+		.entrypoint = "main0",
+		.format = SDL_GPU_SHADERFORMAT_METALLIB,
+		.stage = SDL_GPU_SHADERSTAGE_FRAGMENT,
+	};
 
 	shader_manager->load_shader (
-		ShaderConfig{
-			.path = shader_base + "bin/screen.vert.metallib",
-			.entrypoint = "main0",
-			.format = SDL_GPU_SHADERFORMAT_METALLIB,
-			.stage = SDL_GPU_SHADERSTAGE_VERTEX,
-			.num_uniform_buffers = 1
-		},
-		ShaderConfig{
-			.path = shader_base + "bin/lighting.frag.metallib",
-			.entrypoint = "main0",
-			.format = SDL_GPU_SHADERFORMAT_METALLIB,
-			.stage = SDL_GPU_SHADERSTAGE_FRAGMENT,
-			.num_uniform_buffers = 1,
-			.num_samplers = 3
-		},
-		"lighting"
+		geometry_vertex_shader, geometry_fragment_shader
+	);
+
+	auto lighting_vertex_shader = Shader{
+		.name = "screen",
+		.path = shader_base + "bin/screen.vert.metallib",
+		.entrypoint = "main0",
+		.format = SDL_GPU_SHADERFORMAT_METALLIB,
+		.stage = SDL_GPU_SHADERSTAGE_VERTEX,
+	};
+
+	auto lighting_fragment_shader = Shader{
+		.name = "lighting",
+		.path = shader_base + "bin/lighting.frag.metallib",
+		.entrypoint = "main0",
+		.format = SDL_GPU_SHADERFORMAT_METALLIB,
+		.stage = SDL_GPU_SHADERSTAGE_FRAGMENT,
+	};
+
+	shader_manager->load_shader (
+		lighting_vertex_shader, lighting_fragment_shader
 	);
 
 	assert (shader_manager->get_shader ("geometry"));

--- a/src/engine/render/shaders/shader.cpp
+++ b/src/engine/render/shaders/shader.cpp
@@ -9,210 +9,252 @@ ShaderManager::ShaderManager (SDL_GPUDevice* device) : device (device) {}
 
 ShaderManager::~ShaderManager () = default;
 
-std::vector<ShaderSampler>
-ShaderManager::load_samplers (const std::string& json_path) {
-	std::ifstream file (json_path);
+std::optional<DataTypes> ShaderManager::from_string (std::string_view string) {
+	if (string == "float")
+		return DataTypes::Float;
+	if (string == "vec2")
+		return DataTypes::Vec2;
+	if (string == "vec3")
+		return DataTypes::Vec3;
+	if (string == "vec4")
+		return DataTypes::Vec4;
+	if (string == "mat4")
+		return DataTypes::Mat4;
+	if (string == "int")
+		return DataTypes::Int;
+	return std::nullopt;
+}
+
+uint32_t ShaderManager::size_bytes (DataTypes data_type) {
+	switch (data_type) {
+	case DataTypes::Float:
+		return 4;
+	case DataTypes::Vec2:
+		return 8;
+	case DataTypes::Vec3:
+		return 12;
+	case DataTypes::Vec4:
+		return 16;
+	case DataTypes::Mat4:
+		return 64;
+	case DataTypes::Int:
+		return 4;
+	default:
+		return 0;
+	}
+}
+
+void ShaderManager::load_sampled_textures (Shader& shader) {
+	std::ifstream file (shader.json_path ());
 	if (!file.is_open ())
-		return {};
+		return;
 
 	nlohmann::json data = nlohmann::json::parse (file);
-	std::vector<ShaderSampler> samplers;
+	std::vector<SampledTexture> sampled_textures;
 
 	if (data.contains ("textures")) {
-		for (const auto& tex : data["textures"]) {
-			ShaderSampler s;
-			s.name = tex["name"];
-			s.set = tex["set"];
-			s.binding = tex["binding"];
-			samplers.push_back (s);
+		for (const auto& texture : data["textures"]) {
+			SampledTexture sampled_texture;
+			sampled_texture.name = texture["name"];
+			sampled_texture.set = texture["set"];
+			sampled_texture.binding = texture["binding"];
+			sampled_textures.push_back (sampled_texture);
 		}
 	}
-	return samplers;
+
+	shader.sampled_textures = sampled_textures;
 }
 
-std::vector<VertexAttribute>
-ShaderManager::load_vertex_attributes (const std::string& json_path) {
-	std::ifstream file (json_path);
+void ShaderManager::load_vertex_buffers (Shader& shader) {
+	std::ifstream file (shader.json_path ());
 	if (!file.is_open ()) {
 		SDL_LogError (
 			SDL_LOG_CATEGORY_ERROR, "Failed to open shader metadata: '%s'.",
-			json_path.c_str ()
+			shader.json_path ().c_str ()
 		);
-		return {};
+		return;
 	}
-
-	SDL_LogInfo (
-		SDL_LOG_CATEGORY_RENDER, "Loading vertex attributes from: '%s'.",
-		json_path.c_str ()
-	);
 
 	nlohmann::json data = nlohmann::json::parse (file);
-	std::vector<VertexAttribute> attribute_info;
 
-	if (data.contains ("inputs")) {
-		for (const auto& input : data["inputs"]) {
-			std::string json_type = input["type"];
+	shader.vertex_buffers.clear ();
 
-			auto it = SHADER_TYPE_LOOKUP.find (json_type);
-			if (it != SHADER_TYPE_LOOKUP.end ()) {
-				VertexAttribute info;
-				info.name = input.value ("name", "unknown");
-				info.location = input.value ("location", 0);
-				info.type = it->second;
-
-				attribute_info.push_back (info);
-			} else {
-				SDL_LogError (
-					SDL_LOG_CATEGORY_ERROR,
-					"Warning: Unsupported shader input type '%s' in %s.",
-					json_type.c_str (), json_path.c_str ()
-				);
-				return {};
-			}
-		}
+	if (!data.contains ("inputs")) {
+		SDL_LogError (
+			SDL_LOG_CATEGORY_ERROR, "Shader metadata '%s' missing 'inputs'.",
+			shader.json_path ().c_str ()
+		);
+		return;
 	}
 
-	return attribute_info;
+	std::vector<VertexBufferField> vertex_buffer_fields;
+	vertex_buffer_fields.reserve (data["inputs"].size ());
+
+	for (const auto& input : data["inputs"]) {
+		std::string json_type = input.value ("type", "");
+		auto data_type = from_string (json_type);
+		if (!data_type) {
+			SDL_LogError (
+				SDL_LOG_CATEGORY_ERROR,
+				"Unsupported shader input type '%s' in %s.", json_type.c_str (),
+				shader.json_path ().c_str ()
+			);
+			return;
+		}
+
+		VertexBufferField field;
+		field.name = input.value ("name", "unknown");
+		field.location = input.value ("location", 0u);
+		field.type = *data_type;
+		vertex_buffer_fields.push_back (std::move (field));
+	}
+
+	std::ranges::sort (vertex_buffer_fields, [] (auto& a, auto& b) {
+		return a.location < b.location;
+	});
+
+	for (auto& field : vertex_buffer_fields) {
+		const uint32_t slot = (field.location < 4) ? 0u : 1u;
+
+		auto& [stride, input_rate, fields] = shader.vertex_buffers[slot];
+		if (fields.empty ()) {
+			input_rate = (slot == 0) ? InputRate::PerVertex
+									 : InputRate::PerInstance;
+			stride = 0;
+		}
+
+		field.offset = stride;
+		stride += size_bytes (field.type);
+
+		fields.push_back (field);
+	}
 }
 
-std::unordered_map<std::string, UniformBlock>
-ShaderManager::load_uniform_blocks (const std::string& json_path) {
-	std::ifstream file (json_path);
+void ShaderManager::load_uniform_buffers (Shader& shader) {
+	std::ifstream file (shader.json_path ());
 	if (!file.is_open ()) {
 		SDL_LogError (
 			SDL_LOG_CATEGORY_ERROR, "Failed to open shader metadata: '%s'.",
-			json_path.c_str ()
+			shader.json_path ().c_str ()
 		);
-		return {};
+		return;
 	}
 
 	SDL_LogInfo (
 		SDL_LOG_CATEGORY_RENDER, "Loading uniform blocks from: '%s'.",
-		json_path.c_str ()
+		shader.json_path ().c_str ()
 	);
 
 	nlohmann::json data = nlohmann::json::parse (file);
-	std::unordered_map<std::string, UniformBlock> uniform_blocks;
+	std::unordered_map<std::string, UniformBuffer> unform_buffers;
 
 	if (data.contains ("ubos")) {
 		for (const auto& ubo : data["ubos"]) {
-			UniformBlock block;
-			block.name = ubo["name"];
-			block.binding = ubo["binding"];
-			block.total_size = ubo["block_size"];
+			UniformBuffer uniform_buffer;
+			uniform_buffer.name = ubo["name"];
+			uniform_buffer.binding = ubo["binding"];
+			uniform_buffer.total_size = ubo["block_size"];
 
 			std::string type_id = ubo["type"];
-			auto members_json = data["types"][type_id]["members"];
+			auto fields_json = data["types"][type_id]["members"];
 
-			for (const auto& m : members_json) {
-				UniformMember member;
-				member.name = m["name"];
-				member.offset = m["offset"];
+			for (const auto& field_json : fields_json) {
+				UniformBufferField field;
+				field.name = field_json["name"];
+				field.offset = field_json["offset"];
 
-				std::string m_type = m["type"];
-				if (SHADER_TYPE_LOOKUP.count (m_type)) {
-					member.type = SHADER_TYPE_LOOKUP.at (m_type);
-					member.size = ShaderTypeUtils::get_size (member.type);
+				if (std::string type = field_json["type"]; true) {
+					auto maybe_type = from_string (type);
+					if (!maybe_type) {
+						SDL_LogError (
+							SDL_LOG_CATEGORY_ERROR,
+							"Unsupported uniform field type '%s' in %s.",
+							type.c_str (), shader.json_path ().c_str ()
+						);
+						return;
+					}
+
+					field.type = *maybe_type;
+					field.size = size_bytes (field.type);
 				}
-				block.members[member.name] = member;
+
+				uniform_buffer.fields[field.name] = field;
 			}
-			uniform_blocks[block.name] = block;
+			unform_buffers[uniform_buffer.name] = uniform_buffer;
 		}
 	}
 
-	return uniform_blocks;
+	shader.uniform_buffers = unform_buffers;
 }
 
 bool ShaderManager::load_shader (
-	const ShaderConfig& vertex_config, const ShaderConfig& fragment_config,
-	const std::string& name
+	Shader& vertex_shader, Shader& fragment_shader
 ) {
-	if (get_shader (name)) {
+	if (get_shader (vertex_shader.name)) {
 		SDL_LogWarn (
-			SDL_LOG_CATEGORY_RENDER, "Shader '%s' already loaded. Skipping.",
-			name.c_str ()
+			SDL_LOG_CATEGORY_RENDER,
+			"Vertex shader '%s' already loaded. Skipping.",
+			vertex_shader.name.c_str ()
 		);
 		return false;
 	}
 
-	Shader shader;
-	shader.name = name;
-
-	shader.vertex_shader = compile_shader (vertex_config);
-	shader.fragment_shader = compile_shader (fragment_config);
-
-	std::string json_path = vertex_config.path;
-	size_t last_dot = json_path.find_last_of ('.');
-	if (last_dot != std::string::npos) {
-		json_path = json_path.substr (0, last_dot) + ".json";
-	}
-
-	shader.samplers = load_samplers (json_path);
-
-	shader.uniform_blocks = load_uniform_blocks (json_path);
-	if (shader.uniform_blocks.empty ()) {
+	if (get_shader (fragment_shader.name)) {
 		SDL_LogWarn (
 			SDL_LOG_CATEGORY_RENDER,
-			"Shader '%s' has missing/invalid uniform "
-			"metadata.",
-			name.c_str ()
+			"Fragment shader '%s' already loaded. Skipping.",
+			fragment_shader.name.c_str ()
 		);
+		return false;
 	}
 
-	std::vector<VertexAttribute> vertex_attributes = load_vertex_attributes (
-		json_path
-	);
-
-	std::sort (
-		vertex_attributes.begin (), vertex_attributes.end (),
-		[] (const VertexAttribute& a, const VertexAttribute& b) {
-			return a.location < b.location;
-		}
-	);
-
-	if (vertex_attributes.empty ()) {
+	load_sampled_textures (vertex_shader);
+	load_sampled_textures (fragment_shader);
+	if (vertex_shader.sampled_textures.empty ()) {
 		SDL_LogWarn (
 			SDL_LOG_CATEGORY_RENDER,
-			"Shader '%s' has missing/invalid vertex "
-			"metadata.",
-			name.c_str ()
+			"No sampled textures found for vertex shader: '%s'",
+			vertex_shader.name.c_str ()
 		);
 	}
-
-	std::vector<SDL_GPUVertexAttribute> sdl_attributes;
-
-	for (const auto& attribute : vertex_attributes) {
-		uint32_t slot = (attribute.location < 4) ? 0 : 1;
-
-		if (!shader.vertex_buffer_layouts.contains (slot)) {
-			shader.vertex_buffer_layouts[slot].input_rate
-				= (slot == 0) ? SDL_GPU_VERTEXINPUTRATE_VERTEX
-							  : SDL_GPU_VERTEXINPUTRATE_INSTANCE;
-		}
-
-		VertexBufferLayout& layout = shader.vertex_buffer_layouts[slot];
-		layout.attributes.push_back (attribute);
-
-		SDL_GPUVertexAttribute sdl_attribute;
-		sdl_attribute.location = attribute.location;
-		sdl_attribute.buffer_slot = slot;
-		sdl_attribute.format = ShaderTypeUtils::get_sdl_format (attribute.type);
-		sdl_attribute.offset = layout.stride;
-
-		layout.sdl_attributes.push_back (sdl_attribute);
-
-		layout.stride += ShaderTypeUtils::get_size (attribute.type);
-	}
-
-	for (auto const& [slot, layout] : shader.vertex_buffer_layouts) {
-		SDL_LogInfo (
+	if (fragment_shader.sampled_textures.empty ()) {
+		SDL_LogWarn (
 			SDL_LOG_CATEGORY_RENDER,
-			"Shader '%s' Slot %u: Stride %u bytes, %zu attributes mapped.",
-			name.c_str (), slot, layout.stride, layout.sdl_attributes.size ()
+			"No sampled textures found for fragment shader: '%s'",
+			fragment_shader.name.c_str ()
 		);
 	}
 
-	shaders[name] = shader;
+	load_uniform_buffers (vertex_shader);
+	load_uniform_buffers (fragment_shader);
+	if (vertex_shader.uniform_buffers.empty ()) {
+		SDL_LogWarn (
+			SDL_LOG_CATEGORY_RENDER,
+			"No uniform buffers found for shader: '%s'",
+			vertex_shader.name.c_str ()
+		);
+	}
+	if (fragment_shader.uniform_buffers.empty ()) {
+		SDL_LogWarn (
+			SDL_LOG_CATEGORY_RENDER,
+			"No uniform buffers found for shader: '%s'",
+			fragment_shader.name.c_str ()
+		);
+	}
+
+	load_vertex_buffers (vertex_shader);
+	if (vertex_shader.vertex_buffers.empty ()) {
+		SDL_LogWarn (
+			SDL_LOG_CATEGORY_RENDER, "No vertex buffers found for shader: '%s'",
+			vertex_shader.name.c_str ()
+		);
+	}
+
+	compile_shader (vertex_shader);
+	compile_shader (fragment_shader);
+
+	shaders[vertex_shader.name] = vertex_shader;
+	shaders[fragment_shader.name] = fragment_shader;
 	return true;
 }
 
@@ -225,42 +267,41 @@ void ShaderManager::add_shader (const Shader& shader) {
 	shaders.emplace (shader.name, shader);
 }
 
-SDL_GPUShader*
-ShaderManager::compile_shader (const ShaderConfig& shader_config) const {
+void ShaderManager::compile_shader (Shader& shader) const {
 	SDL_LogMessage (
 		SDL_LOG_CATEGORY_RENDER, SDL_LOG_PRIORITY_INFO,
-		"Compiling shader stage: %s", shader_config.path.c_str ()
+		"Compiling shader stage: %s", shader.path.c_str ()
 	);
 
-	SDL_IOStream* file = SDL_IOFromFile (shader_config.path.c_str (), "rb");
+	SDL_IOStream* file = SDL_IOFromFile (shader.path.c_str (), "rb");
 	if (!file) {
 		SDL_LogError (
 			SDL_LOG_CATEGORY_RENDER, "Failed to open shader: '%s'.",
-			shader_config.path.c_str ()
+			shader.path.c_str ()
 		);
 		SDL_CloseIO (file);
-		return nullptr;
+		return;
 	}
 
 	const Sint64 size = SDL_GetIOSize (file);
 	if (size <= 0) {
 		SDL_LogError (
 			SDL_LOG_CATEGORY_RENDER, "Shader file has invalid size: %s.",
-			shader_config.path.c_str ()
+			shader.path.c_str ()
 		);
 		SDL_CloseIO (file);
-		return nullptr;
+		return;
 	}
 
 	std::string source (size, '\0');
-	const Sint64 read = SDL_ReadIO (file, source.data (), size);
-	if (read != size) {
+	if (const Sint64 read = SDL_ReadIO (file, source.data (), size);
+		read != size) {
 		SDL_LogError (
 			SDL_LOG_CATEGORY_RENDER, "Failed to read entire shader file: %s.",
-			shader_config.path.c_str ()
+			shader.path.c_str ()
 		);
 		SDL_CloseIO (file);
-		return nullptr;
+		return;
 	}
 
 	SDL_CloseIO (file);
@@ -268,30 +309,28 @@ ShaderManager::compile_shader (const ShaderConfig& shader_config) const {
 	const SDL_GPUShaderCreateInfo info = {
 		.code_size = static_cast<size_t> (size),
 		.code = reinterpret_cast<const Uint8*> (source.data ()),
-		.entrypoint = shader_config.entrypoint.c_str (),
-		.format = shader_config.format,
-		.stage = shader_config.stage,
-		.num_samplers = shader_config.num_samplers,
-		.num_storage_textures = shader_config.num_storage_textures,
-		.num_storage_buffers = shader_config.num_storage_buffers,
-		.num_uniform_buffers = shader_config.num_uniform_buffers,
-		.props = shader_config.props
+		.entrypoint = shader.entrypoint.c_str (),
+		.format = shader.format,
+		.stage = shader.stage,
+		.num_samplers = static_cast<Uint32> (shader.sampled_textures.size ()),
+		.num_storage_textures = 0,
+		.num_storage_buffers = 0,
+		.num_uniform_buffers
+		= static_cast<Uint32> (shader.uniform_buffers.size ()),
+		.props = 0
 	};
 
-	SDL_GPUShader* shader = SDL_CreateGPUShader (device, &info);
+	shader.shader = SDL_CreateGPUShader (device, &info);
 
-	if (!shader) {
+	if (!shader.shader) {
 		SDL_LogError (
 			SDL_LOG_CATEGORY_RENDER, "Shader compilation failed for '%s': %s",
-			shader_config.path.c_str (), SDL_GetError ()
+			shader.path.c_str (), SDL_GetError ()
 		);
 	} else {
 		SDL_LogMessage (
 			SDL_LOG_CATEGORY_RENDER, SDL_LOG_PRIORITY_INFO,
-			"Successfully compiled shader stage: %s",
-			shader_config.path.c_str ()
+			"Successfully compiled shader stage: %s", shader.path.c_str ()
 		);
 	}
-
-	return shader;
 }

--- a/tests/engine/render/test_material.cpp
+++ b/tests/engine/render/test_material.cpp
@@ -8,7 +8,8 @@ class MaterialStateTest : public ::testing::Test {
 
 	void SetUp () override {
 		base_state = {
-			.shader = "test_shader",
+			.vertex_shader = "vertex_shader",
+			.fragment_shader = "fragement_shader",
 			.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
 			.cull_mode = SDL_GPU_CULLMODE_BACK,
 			.compare_op = SDL_GPU_COMPAREOP_LESS,
@@ -25,7 +26,8 @@ TEST_F (MaterialStateTest, EqualityOperatorTrueForSameState) {
 
 TEST_F (MaterialStateTest, EqualityOperatorFalseForDifferentShader) {
 	MaterialState other = base_state;
-	other.shader = "other_shader";
+	other.vertex_shader = "other_vertex_shader";
+	other.fragment_shader = "other_vertex_shader";
 
 	EXPECT_FALSE (base_state == other);
 }
@@ -72,7 +74,8 @@ TEST_F (MaterialStateTest, DifferentShaderProducesDifferentHash) {
 	constexpr std::hash<MaterialState> hasher;
 
 	MaterialState other = base_state;
-	other.shader = "other_shader";
+	other.vertex_shader = "other_vertex_shader";
+	other.fragment_shader = "other_vertex_shader";
 
 	EXPECT_NE (hasher (base_state), hasher (other));
 }

--- a/tests/engine/render/test_pipelines.cpp
+++ b/tests/engine/render/test_pipelines.cpp
@@ -16,7 +16,8 @@ class FakePipelineFactory final : public IPipelineFactory {
 			0xDEADBEEF
 		);
 
-		pipeline->name = state.material_state.shader;
+		pipeline->name = state.material_state.vertex_shader + "_"
+						 + state.material_state.fragment_shader;
 
 		return pipeline;
 	}
@@ -38,7 +39,8 @@ class PipelineManagerTest : public ::testing::Test {
 		};
 
 		material_state = {
-			.shader = "test_shader",
+			.vertex_shader = "vertex_shader",
+			.fragment_shader = "fragment_shader",
 			.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
 			.cull_mode = SDL_GPU_CULLMODE_BACK,
 			.compare_op = SDL_GPU_COMPAREOP_LESS,
@@ -100,7 +102,8 @@ TEST_F (PipelineManagerTest, EquivalentStatesProduceSameHash) {
 
 TEST_F (PipelineManagerTest, DifferentMaterialStateIsNotEqual) {
 	MaterialState different = material_state;
-	different.shader = "other_shader";
+	different.vertex_shader = "other_vertex_shader";
+	different.fragment_shader = "other_fragment_shader";
 
 	const PipelineState other{
 		.render_pass_state = render_pass_state,
@@ -117,7 +120,8 @@ TEST_F (PipelineManagerTest, DifferentStateCreatesDifferentPipeline) {
 	Pipeline* first = pipeline_manager.get_or_create (pipeline_state);
 
 	MaterialState different = material_state;
-	different.shader = "other_shader";
+	different.vertex_shader = "other_vertex_shader";
+	different.fragment_shader = "other_fragment_shader";
 
 	const PipelineState other{
 		.render_pass_state = render_pass_state,


### PR DESCRIPTION
## Summary
Wanted to refactor a lot of the shader and buffer code since there was some code debt surrounding reading reflections and coupling to SDL.

## Motivation
Eventually want to move to full dynamic shader compilation, need proper reflection reading for this. Also want to swap backends easily.

## Key changes
<!-- Bullet list of the most important changes -->
- Isolated SDL-related types in the `SDLPipelineFactory` class.
- Refactored a lot of the shader loading and compilation logic.
- Separated out vertex and fragment shaders.

## Architectural notes (if applicable)
<!-- Any ownership changes, invariants, or mental-model shifts -->
Material now owns vertex and fragment shaders atomically instead of as an aggregate.

## Follow-ups
<!-- Things intentionally left out or planned next steps -->
- Still not parsing and reading storage buffers or textures.

## Checklist
- [x] Builds and runs locally
- [x] No new warnings
- [x] Naming and ownership make sense
- [x] Has tests