### PR TITLE
Core Architecture: Decoupling Render Pass from Graphical Backends

### DIFF
--- a/src/engine/core/types.h
+++ b/src/engine/core/types.h
@@ -1,0 +1,62 @@
+#ifndef TYPES_H
+#define TYPES_H
+#include <cstdint>
+
+enum class CompareOp : uint8_t {
+	Never,
+	Less,
+	Equal,
+	LessOrEqual,
+	Greater,
+	NotEqual,
+	GreaterOrEqual,
+	Always
+};
+
+enum class LoadOp : uint8_t { Load, Clear, DontCare };
+
+enum class StoreOp : uint8_t { Store, DontCare };
+
+struct Color4 {
+	float r = 0.0f;
+	float g = 0.0f;
+	float b = 0.0f;
+	float a = 1.0f;
+};
+
+enum class PrimitiveType : uint8_t {
+	TriangleList,
+	TriangleStrip,
+	LineList,
+	LineStrip,
+	PointList
+};
+
+enum class CullMode : uint8_t { None, Front, Back };
+
+enum class TextureFormat : uint8_t {
+	Invalid,
+	RGBA8,
+	RGBA16F,
+	BGRA8,
+	D32F,
+};
+
+enum class TextureUsage : uint32_t {
+	None = 0,
+	ColorTarget = 1u << 0,
+	DepthStencil = 1u << 1,
+	Sampled = 1u << 2,
+	Storage = 1u << 3,
+};
+
+inline TextureUsage operator| (TextureUsage a, TextureUsage b) {
+	return static_cast<TextureUsage> (
+		static_cast<uint32_t> (a) | static_cast<uint32_t> (b)
+	);
+}
+inline bool operator& (TextureUsage a, TextureUsage b) {
+	return (static_cast<uint32_t> (a) & static_cast<uint32_t> (b)) != 0;
+}
+
+#endif // TYPES_H

--- a/src/engine/render/frame/frame.cpp
+++ b/src/engine/render/frame/frame.cpp
@@ -12,63 +12,126 @@
 #include "render/context.h"
 #include "render/textures/registry.h"
 
+static SDL_GPULoadOp to_sdl_load_op (const LoadOp op) {
+	switch (op) {
+	case LoadOp::Load:
+		return SDL_GPU_LOADOP_LOAD;
+	case LoadOp::Clear:
+		return SDL_GPU_LOADOP_CLEAR;
+	case LoadOp::DontCare:
+		return SDL_GPU_LOADOP_DONT_CARE;
+	}
+	return SDL_GPU_LOADOP_LOAD;
+}
+
+static SDL_FColor to_sdl_color (const Color4& c) {
+	SDL_FColor out{};
+	out.r = c.r;
+	out.g = c.g;
+	out.b = c.b;
+	out.a = c.a;
+	return out;
+}
+
 SDL_GPURenderPass* FrameManager::begin_render_pass (
 	const RenderPassInstance& render_pass_instance,
-	const BufferManager& buffer_manager
+	const RenderContext& render_context
 ) const {
 	assert (render_pass_instance.type != RenderPassType::Setup);
 
-	assert (buffer_manager.command_buffer);
-	assert (buffer_manager.depth_texture);
-	assert (buffer_manager.swap_chain_texture);
+	assert (render_context.buffer_manager);
+	assert (render_context.buffer_manager->command_buffer);
+	assert (render_context.buffer_manager->swap_chain_texture);
+	assert (render_context.texture_registry);
 
-	assert (!render_pass_instance.target_textures.empty ());
-
-	for (const auto color_target : render_pass_instance.target_textures) {
-		assert (color_target);
+	if (render_pass_instance.depth_target) {
+		assert (render_context.buffer_manager->depth_texture);
 	}
 
-	assert (render_pass_instance.target_textures.size () <= 8);
+	assert (
+		render_pass_instance.swap_chain_target
+		|| !render_pass_instance.target_textures.empty ()
+	);
+
+	assert (
+		!(render_pass_instance.swap_chain_target
+		  && !render_pass_instance.target_textures.empty ())
+	);
 
 	std::vector<SDL_GPUColorTargetInfo> color_target_infos;
-	color_target_infos.reserve (render_pass_instance.target_textures.size ());
 
-	for (SDL_GPUTexture* texture : render_pass_instance.target_textures) {
-		assert (texture);
+	if (render_pass_instance.swap_chain_target) {
+		color_target_infos.reserve (1);
 
 		SDL_GPUColorTargetInfo info{};
-		info.texture = texture;
+		info.texture = render_context.buffer_manager->swap_chain_texture;
 		info.mip_level = 0;
 		info.layer_or_depth_plane = 0;
-		info.clear_color = render_pass_instance.clear_color;
-		info.load_op = render_pass_instance.load_op;
+		info.clear_color = to_sdl_color (render_pass_instance.clear_color);
+		info.load_op = to_sdl_load_op (render_pass_instance.load_op);
 		info.store_op = SDL_GPU_STOREOP_STORE;
 		info.resolve_texture = nullptr;
-		info.cycle = (info.load_op == SDL_GPU_LOADOP_CLEAR);
+
+		info.cycle = (info.load_op != SDL_GPU_LOADOP_LOAD);
 		info.cycle_resolve_texture = false;
 
 		color_target_infos.push_back (info);
+	} else {
+		assert (render_pass_instance.target_textures.size () <= 8);
+		color_target_infos.reserve (
+			render_pass_instance.target_textures.size ()
+		);
+
+		for (const Handle handle : render_pass_instance.target_textures) {
+			assert (handle.valid ());
+
+			SDL_GPUTexture* texture
+				= render_context.texture_registry->resolve_texture (handle);
+			assert (texture);
+
+			SDL_GPUColorTargetInfo info{};
+			info.texture = texture;
+			info.mip_level = 0;
+			info.layer_or_depth_plane = 0;
+			info.clear_color = to_sdl_color (render_pass_instance.clear_color);
+			info.load_op = to_sdl_load_op (render_pass_instance.load_op);
+			info.store_op = SDL_GPU_STOREOP_STORE;
+			info.resolve_texture = nullptr;
+
+			info.cycle = (info.load_op != SDL_GPU_LOADOP_LOAD);
+			info.cycle_resolve_texture = false;
+
+			color_target_infos.push_back (info);
+		}
 	}
 
 	assert (!color_target_infos.empty ());
 
 	if (render_pass_instance.depth_target) {
-		assert (render_pass_instance.depth_target);
+		SDL_GPUTexture* texture = render_context.buffer_manager->depth_texture;
+		assert (texture);
 
 		SDL_GPUDepthStencilTargetInfo depth_target_info{};
-		depth_target_info.texture = render_pass_instance.depth_target;
+		depth_target_info.texture = texture;
 		depth_target_info.clear_depth = render_pass_instance.clear_depth ? 1.0f
 																		 : 0.0f;
+
 		depth_target_info.load_op = render_pass_instance.clear_depth
 										? SDL_GPU_LOADOP_CLEAR
 										: SDL_GPU_LOADOP_LOAD;
+
 		depth_target_info.store_op = SDL_GPU_STOREOP_DONT_CARE;
 		depth_target_info.stencil_load_op = SDL_GPU_LOADOP_DONT_CARE;
 		depth_target_info.stencil_store_op = SDL_GPU_STOREOP_DONT_CARE;
-		depth_target_info.cycle = true;
+
+		depth_target_info.cycle = (depth_target_info.load_op
+								   != SDL_GPU_LOADOP_LOAD)
+								  && (depth_target_info.stencil_load_op
+									  != SDL_GPU_LOADOP_LOAD);
 
 		SDL_GPURenderPass* render_pass = SDL_BeginGPURenderPass (
-			buffer_manager.command_buffer, color_target_infos.data (),
+			render_context.buffer_manager->command_buffer,
+			color_target_infos.data (),
 			static_cast<uint32_t> (color_target_infos.size ()),
 			&depth_target_info
 		);
@@ -78,7 +141,8 @@ SDL_GPURenderPass* FrameManager::begin_render_pass (
 	}
 
 	SDL_GPURenderPass* render_pass = SDL_BeginGPURenderPass (
-		buffer_manager.command_buffer, color_target_infos.data (),
+		render_context.buffer_manager->command_buffer,
+		color_target_infos.data (),
 		static_cast<uint32_t> (color_target_infos.size ()), nullptr
 	);
 
@@ -215,16 +279,26 @@ void FrameManager::draw_screen (
 
 	assert (render_pass_instance.sampled_textures.size () == 3);
 
-	SDL_GPUTexture* gbuffer_position_texture
-		= render_pass_instance.sampled_textures[0];
-	SDL_GPUTexture* gbuffer_normal_texture
-		= render_pass_instance.sampled_textures[1];
-	SDL_GPUTexture* gbuffer_albedo_texture
-		= render_pass_instance.sampled_textures[2];
+	Handle gbuffer_position_handle = render_pass_instance.sampled_textures[0];
+	Handle gbuffer_normal_handle = render_pass_instance.sampled_textures[1];
+	Handle gbuffer_albedo_handle = render_pass_instance.sampled_textures[2];
 
-	assert (gbuffer_position_texture);
-	assert (gbuffer_normal_texture);
-	assert (gbuffer_albedo_texture);
+	assert (gbuffer_position_handle.valid ());
+	assert (gbuffer_normal_handle.valid ());
+	assert (gbuffer_albedo_handle.valid ());
+
+	SDL_GPUTexture* gbuffer_position_texture
+		= render_context.texture_registry->resolve_texture (
+			gbuffer_position_handle
+		);
+	SDL_GPUTexture* gbuffer_normal_texture
+		= render_context.texture_registry->resolve_texture (
+			gbuffer_normal_handle
+		);
+	SDL_GPUTexture* gbuffer_albedo_texture
+		= render_context.texture_registry->resolve_texture (
+			gbuffer_albedo_handle
+		);
 
 	SDL_BindGPUGraphicsPipeline (
 		render_context.render_pass, pipeline->pipeline

--- a/src/engine/render/frame/frame.h
+++ b/src/engine/render/frame/frame.h
@@ -16,7 +16,7 @@ class FrameManager {
   public:
 	[[nodiscard]] SDL_GPURenderPass* begin_render_pass (
 		const RenderPassInstance& render_pass_instance,
-		const BufferManager& buffer_manager
+		const RenderContext& render_context
 	) const;
 
 	void set_viewport (

--- a/src/engine/render/material.h
+++ b/src/engine/render/material.h
@@ -3,23 +3,29 @@
 
 #include "utils.h"
 
-#include <SDL3/SDL_gpu.h>
+#include <functional>
 #include <string>
 
+#include <glm/vec4.hpp>
+
+#include "core/types.h"
+
 struct MaterialState {
-	std::string vertex_shader;
-	std::string fragment_shader;
-	SDL_GPUPrimitiveType primitive_type;
-	SDL_GPUCullMode cull_mode;
-	SDL_GPUCompareOp compare_op;
-	bool enable_depth_test;
-	bool enable_depth_write;
+	std::string vertex_shader{};
+	std::string fragment_shader{};
+
+	PrimitiveType primitive_type = PrimitiveType::TriangleList;
+	CullMode cull_mode = CullMode::Back;
+	CompareOp compare_op = CompareOp::Less;
+
+	bool enable_depth_test = true;
+	bool enable_depth_write = true;
 
 	bool operator== (const MaterialState& other) const {
 		return vertex_shader == other.vertex_shader
 			   && fragment_shader == other.fragment_shader
 			   && primitive_type == other.primitive_type
-			   && cull_mode == other.cull_mode && compare_op
+			   && cull_mode == other.cull_mode
 			   && enable_depth_test == other.enable_depth_test
 			   && enable_depth_write == other.enable_depth_write
 			   && (!enable_depth_test || compare_op == other.compare_op);
@@ -27,25 +33,40 @@ struct MaterialState {
 };
 
 struct MaterialInstance {
-	std::string name;
-	MaterialState state;
-	glm::vec4 base_color = {1.0f, 1.0f, 1.0f, 1.0f};
+	std::string name{};
+	MaterialState state{};
+
+	glm::vec4 base_color{1.0f, 1.0f, 1.0f, 1.0f};
+
+	// TODO:
+	// Handle albedo_texture{};
+	// Handle normal_texture{};
+	// Handle orm_texture{};
 };
 
 template <> struct std::hash<MaterialState> {
 	size_t operator() (const MaterialState& material) const noexcept {
 		size_t h = 0;
 
-		hash_combine (h, std::hash<std::string> () (material.vertex_shader));
-		hash_combine (h, std::hash<std::string> () (material.fragment_shader));
-		hash_combine (h, std::hash<int> () (material.primitive_type));
-		hash_combine (h, std::hash<int> () (material.cull_mode));
+		hash_combine (h, std::hash<std::string>{}(material.vertex_shader));
+		hash_combine (h, std::hash<std::string>{}(material.fragment_shader));
 
-		hash_combine (h, std::hash<bool> () (material.enable_depth_test));
-		hash_combine (h, std::hash<bool> () (material.enable_depth_write));
+		hash_combine (
+			h,
+			std::hash<uint8_t>{}(static_cast<uint8_t> (material.primitive_type))
+		);
+		hash_combine (
+			h, std::hash<uint8_t>{}(static_cast<uint8_t> (material.cull_mode))
+		);
+
+		hash_combine (h, std::hash<bool>{}(material.enable_depth_test));
+		hash_combine (h, std::hash<bool>{}(material.enable_depth_write));
 
 		if (material.enable_depth_test) {
-			hash_combine (h, std::hash<int> () (material.compare_op));
+			hash_combine (
+				h,
+				std::hash<uint8_t>{}(static_cast<uint8_t> (material.compare_op))
+			);
 		}
 
 		return h;
@@ -53,14 +74,15 @@ template <> struct std::hash<MaterialState> {
 };
 
 namespace Materials {
+
 inline static MaterialInstance Geometry{
 	.name = "geometry",
 	.state
 	= {.vertex_shader = "geometry",
 	   .fragment_shader = "gbuffer",
-	   .primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
-	   .cull_mode = SDL_GPU_CULLMODE_BACK,
-	   .compare_op = SDL_GPU_COMPAREOP_LESS,
+	   .primitive_type = PrimitiveType::TriangleList,
+	   .cull_mode = CullMode::Back,
+	   .compare_op = CompareOp::Less,
 	   .enable_depth_test = true,
 	   .enable_depth_write = true},
 	.base_color = {1.0f, 1.0f, 1.0f, 1.0f}
@@ -71,13 +93,14 @@ inline static MaterialInstance Deferred{
 	.state
 	= {.vertex_shader = "screen",
 	   .fragment_shader = "lighting",
-	   .primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
-	   .cull_mode = SDL_GPU_CULLMODE_BACK,
-	   .compare_op = SDL_GPU_COMPAREOP_LESS,
+	   .primitive_type = PrimitiveType::TriangleList,
+	   .cull_mode = CullMode::Back,
+	   .compare_op = CompareOp::Less,
 	   .enable_depth_test = false,
 	   .enable_depth_write = false},
 	.base_color = {1.0f, 1.0f, 1.0f, 1.0f}
 };
+
 }
 
 #endif // MATERIAL_H

--- a/src/engine/render/pipelines/sdl/factory.cpp
+++ b/src/engine/render/pipelines/sdl/factory.cpp
@@ -39,6 +39,74 @@ SDLPipelineFactory::to_sdl_vertex_format (const DataTypes data_type) {
 	}
 }
 
+SDL_GPUTextureFormat
+SDLPipelineFactory::to_sdl_texture_format (const TextureFormat format) {
+	switch (format) {
+	case TextureFormat::RGBA8:
+		return SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM;
+	case TextureFormat::RGBA16F:
+		return SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT;
+	case TextureFormat::BGRA8:
+		return SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM;
+	case TextureFormat::D32F:
+		return SDL_GPU_TEXTUREFORMAT_D32_FLOAT;
+	case TextureFormat::Invalid:
+	default:
+		return SDL_GPU_TEXTUREFORMAT_INVALID;
+	}
+}
+
+SDL_GPUCompareOp SDLPipelineFactory::to_sdl_compare_op (const CompareOp op) {
+	switch (op) {
+	case CompareOp::Never:
+		return SDL_GPU_COMPAREOP_NEVER;
+	case CompareOp::Less:
+		return SDL_GPU_COMPAREOP_LESS;
+	case CompareOp::Equal:
+		return SDL_GPU_COMPAREOP_EQUAL;
+	case CompareOp::LessOrEqual:
+		return SDL_GPU_COMPAREOP_LESS_OR_EQUAL;
+	case CompareOp::Greater:
+		return SDL_GPU_COMPAREOP_GREATER;
+	case CompareOp::NotEqual:
+		return SDL_GPU_COMPAREOP_NOT_EQUAL;
+	case CompareOp::GreaterOrEqual:
+		return SDL_GPU_COMPAREOP_GREATER_OR_EQUAL;
+	case CompareOp::Always:
+		return SDL_GPU_COMPAREOP_ALWAYS;
+	}
+	return SDL_GPU_COMPAREOP_ALWAYS;
+}
+
+SDL_GPUCullMode SDLPipelineFactory::to_sdl_cull_mode (const CullMode mode) {
+	switch (mode) {
+	case CullMode::None:
+		return SDL_GPU_CULLMODE_NONE;
+	case CullMode::Front:
+		return SDL_GPU_CULLMODE_FRONT;
+	case CullMode::Back:
+		return SDL_GPU_CULLMODE_BACK;
+	}
+	return SDL_GPU_CULLMODE_NONE;
+}
+
+SDL_GPUPrimitiveType
+SDLPipelineFactory::to_sdl_primitive_type (const PrimitiveType type) {
+	switch (type) {
+	case PrimitiveType::TriangleList:
+		return SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+	case PrimitiveType::TriangleStrip:
+		return SDL_GPU_PRIMITIVETYPE_TRIANGLESTRIP;
+	case PrimitiveType::LineList:
+		return SDL_GPU_PRIMITIVETYPE_LINELIST;
+	case PrimitiveType::LineStrip:
+		return SDL_GPU_PRIMITIVETYPE_LINESTRIP;
+	case PrimitiveType::PointList:
+		return SDL_GPU_PRIMITIVETYPE_POINTLIST;
+	}
+	return SDL_GPU_PRIMITIVETYPE_TRIANGLELIST;
+}
+
 Pipeline*
 SDLPipelineFactory::create_pipeline (const PipelineState& pipeline_state) {
 	assert (
@@ -55,19 +123,31 @@ SDLPipelineFactory::create_pipeline (const PipelineState& pipeline_state) {
 		pipeline_state.material_state.fragment_shader
 	);
 
+	if (!vertex_shader || !fragment_shader) {
+		SDL_LogError (
+			SDL_LOG_CATEGORY_ERROR,
+			"Missing shader(s) for pipeline creation: vs='%s', fs='%s'",
+			pipeline_state.material_state.vertex_shader.c_str (),
+			pipeline_state.material_state.fragment_shader.c_str ()
+		);
+		return nullptr;
+	}
+
 	std::vector<SDL_GPUVertexBufferDescription> buffer_descriptions;
-	for (auto const& [slot, vertex_buffer] : vertex_shader->vertex_buffers) {
-		SDL_GPUVertexBufferDescription description = {
-			.slot = slot,
-			.pitch = vertex_buffer.stride,
-			.input_rate = to_sdl_input_rate (vertex_buffer.input_rate),
-			.instance_step_rate = 0
-		};
+	buffer_descriptions.reserve (vertex_shader->vertex_buffers.size ());
+
+	for (const auto& [slot, vertex_buffer] : vertex_shader->vertex_buffers) {
+		SDL_GPUVertexBufferDescription description{};
+		description.slot = slot;
+		description.pitch = vertex_buffer.stride;
+		description.input_rate = to_sdl_input_rate (vertex_buffer.input_rate);
+		description.instance_step_rate = 0;
+
 		buffer_descriptions.push_back (description);
 	}
 
 	std::vector<SDL_GPUVertexAttribute> sdl_attributes;
-	for (auto const& [slot, vertex_buffer] : vertex_shader->vertex_buffers) {
+	for (const auto& [slot, vertex_buffer] : vertex_shader->vertex_buffers) {
 		for (const auto& [name, location, type, offset] :
 			 vertex_buffer.fields) {
 			SDL_GPUVertexAttribute attribute{};
@@ -90,62 +170,86 @@ SDLPipelineFactory::create_pipeline (const PipelineState& pipeline_state) {
 		}
 	}
 
-	SDL_GPUVertexInputState vertex_input_state = {
-		.vertex_buffer_descriptions = buffer_descriptions.data (),
-		.num_vertex_buffers = static_cast<Uint32> (buffer_descriptions.size ()),
-		.vertex_attributes = sdl_attributes.data (),
-		.num_vertex_attributes = static_cast<Uint32> (sdl_attributes.size ())
-	};
+	SDL_GPUVertexInputState vertex_input_state{};
+	vertex_input_state.vertex_buffer_descriptions = buffer_descriptions.data ();
+	vertex_input_state.num_vertex_buffers = static_cast<Uint32> (
+		buffer_descriptions.size ()
+	);
+	vertex_input_state.vertex_attributes = sdl_attributes.data ();
+	vertex_input_state.num_vertex_attributes = static_cast<Uint32> (
+		sdl_attributes.size ()
+	);
 
-	SDL_GPURasterizerState rasterizer_state = {
-		.fill_mode = SDL_GPU_FILLMODE_FILL,
-		.cull_mode = pipeline_state.material_state.cull_mode,
-		.front_face = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE
-	};
+	SDL_GPURasterizerState rasterizer_state{};
+	rasterizer_state.fill_mode = SDL_GPU_FILLMODE_FILL;
+	rasterizer_state.cull_mode = to_sdl_cull_mode (
+		pipeline_state.material_state.cull_mode
+	);
+	rasterizer_state.front_face = SDL_GPU_FRONTFACE_COUNTER_CLOCKWISE;
 
-	SDL_GPUDepthStencilState depth_stencil_state = {
-		.compare_op = pipeline_state.material_state.compare_op,
-		.back_stencil_state = {},
-		.front_stencil_state = {},
-		.enable_depth_test = pipeline_state.material_state.enable_depth_test,
-		.enable_depth_write = pipeline_state.material_state.enable_depth_write,
-		.enable_stencil_test = false
-	};
+	SDL_GPUDepthStencilState depth_stencil_state{};
+	depth_stencil_state.compare_op = to_sdl_compare_op (
+		pipeline_state.material_state.compare_op
+	);
+	depth_stencil_state.back_stencil_state = {};
+	depth_stencil_state.front_stencil_state = {};
+	depth_stencil_state.enable_depth_test
+		= pipeline_state.material_state.enable_depth_test;
+	depth_stencil_state.enable_depth_write
+		= pipeline_state.material_state.enable_depth_write;
+	depth_stencil_state.enable_stencil_test = false;
 
 	std::vector<SDL_GPUColorTargetDescription> color_targets;
+	color_targets.reserve (
+		pipeline_state.render_pass_state.color_formats.size ()
+	);
 
-	for (auto format : pipeline_state.render_pass_state.color_formats) {
+	for (const auto format : pipeline_state.render_pass_state.color_formats) {
 		SDL_GPUColorTargetDescription desc{};
-		desc.format = format;
+		desc.format = to_sdl_texture_format (format);
 		desc.blend_state = {};
 		color_targets.push_back (desc);
 	}
 
-	SDL_GPUGraphicsPipelineTargetInfo target_info = {
-		.num_color_targets = static_cast<Uint32> (color_targets.size ()),
-		.color_target_descriptions = color_targets.data (),
-		.depth_stencil_format = pipeline_state.render_pass_state.depth_format
-									? SDL_GPU_TEXTUREFORMAT_D32_FLOAT
-									: SDL_GPU_TEXTUREFORMAT_INVALID,
-		.has_depth_stencil_target
+	SDL_GPUGraphicsPipelineTargetInfo target_info{};
+	target_info.num_color_targets = static_cast<Uint32> (color_targets.size ());
+	target_info.color_target_descriptions = color_targets.data ();
+	target_info.has_depth_stencil_target
+		= pipeline_state.render_pass_state.has_depth_stencil_target;
+
+	target_info.depth_stencil_format
 		= pipeline_state.render_pass_state.has_depth_stencil_target
-	};
+			  ? to_sdl_texture_format (
+					pipeline_state.render_pass_state.depth_format
+				)
+			  : SDL_GPU_TEXTUREFORMAT_INVALID;
 
-	SDL_GPUGraphicsPipelineCreateInfo pipeline_info = {
-		.vertex_shader = vertex_shader->shader,
-		.fragment_shader = fragment_shader->shader,
-		.vertex_input_state = vertex_input_state,
-		.primitive_type = pipeline_state.material_state.primitive_type,
-		.rasterizer_state = rasterizer_state,
-		.depth_stencil_state = depth_stencil_state,
-		.multisample_state = {},
-		.target_info = target_info,
-		.props = 0
-	};
+	SDL_GPUGraphicsPipelineCreateInfo pipeline_info{};
+	pipeline_info.vertex_shader = vertex_shader->shader;
+	pipeline_info.fragment_shader = fragment_shader->shader;
+	pipeline_info.vertex_input_state = vertex_input_state;
+	pipeline_info.primitive_type = to_sdl_primitive_type (
+		pipeline_state.material_state.primitive_type
+	);
+	pipeline_info.rasterizer_state = rasterizer_state;
+	pipeline_info.depth_stencil_state = depth_stencil_state;
+	pipeline_info.multisample_state = {};
+	pipeline_info.target_info = target_info;
+	pipeline_info.props = 0;
 
-	auto* pipeline = new Pipeline{
-		SDL_CreateGPUGraphicsPipeline (device, &pipeline_info)
-	};
+	SDL_GPUGraphicsPipeline* sdl_pipeline = SDL_CreateGPUGraphicsPipeline (
+		device, &pipeline_info
+	);
 
-	return pipeline;
+	if (!sdl_pipeline) {
+		SDL_LogError (
+			SDL_LOG_CATEGORY_ERROR,
+			"Failed to create graphics pipeline for material VS='%s' FS='%s'",
+			pipeline_state.material_state.vertex_shader.c_str (),
+			pipeline_state.material_state.fragment_shader.c_str ()
+		);
+		return nullptr;
+	}
+
+	return new Pipeline{sdl_pipeline};
 }

--- a/src/engine/render/pipelines/sdl/factory.h
+++ b/src/engine/render/pipelines/sdl/factory.h
@@ -21,6 +21,15 @@ class SDLPipelineFactory : public IPipelineFactory {
 
 	SDL_GPUVertexInputRate to_sdl_input_rate (InputRate input_rate);
 	SDL_GPUVertexElementFormat to_sdl_vertex_format (DataTypes data_type);
+
+	SDL_GPUTextureFormat to_sdl_texture_format (TextureFormat format);
+
+	SDL_GPUCompareOp to_sdl_compare_op (CompareOp op);
+
+	SDL_GPUCullMode to_sdl_cull_mode (CullMode mode);
+
+	SDL_GPUPrimitiveType to_sdl_primitive_type (PrimitiveType type);
+
 	Pipeline* create_pipeline (const PipelineState& pipeline_state) override;
 
   private:

--- a/src/engine/render/textures/registry.h
+++ b/src/engine/render/textures/registry.h
@@ -7,6 +7,7 @@
 #include "core/storage/maps/slot.h"
 #include "core/storage/record.h"
 #include "core/storage/wrappers/target.h"
+#include "core/types.h"
 #include "sdl/factory.h"
 #include "texture.h"
 

--- a/src/engine/render/textures/texture.h
+++ b/src/engine/render/textures/texture.h
@@ -9,33 +9,12 @@
 #include "core/storage/storage.h"
 #include "utils.h"
 
+enum class TextureUsage : uint32_t;
+enum class TextureFormat : uint8_t;
+
 struct TextureHandle {
 	uint32_t id = 0;
 };
-
-enum class TextureFormat : uint8_t {
-	Invalid,
-	RGBA8,
-	RGBA16F,
-	D32F,
-};
-
-enum class TextureUsage : uint32_t {
-	None = 0,
-	ColorTarget = 1u << 0,
-	DepthStencil = 1u << 1,
-	Sampled = 1u << 2,
-	Storage = 1u << 3,
-};
-
-inline TextureUsage operator| (TextureUsage a, TextureUsage b) {
-	return static_cast<TextureUsage> (
-		static_cast<uint32_t> (a) | static_cast<uint32_t> (b)
-	);
-}
-inline bool operator& (TextureUsage a, TextureUsage b) {
-	return (static_cast<uint32_t> (a) & static_cast<uint32_t> (b)) != 0;
-}
 
 struct TextureState final : IState<TextureState> {
 	int width;

--- a/tests/engine/render/test_material.cpp
+++ b/tests/engine/render/test_material.cpp
@@ -10,9 +10,9 @@ class MaterialStateTest : public ::testing::Test {
 		base_state = {
 			.vertex_shader = "vertex_shader",
 			.fragment_shader = "fragement_shader",
-			.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
-			.cull_mode = SDL_GPU_CULLMODE_BACK,
-			.compare_op = SDL_GPU_COMPAREOP_LESS,
+			.primitive_type = PrimitiveType::TriangleList,
+			.cull_mode = CullMode::Back,
+			.compare_op = CompareOp::Less,
 			.enable_depth_test = true,
 			.enable_depth_write = true
 		};
@@ -34,14 +34,14 @@ TEST_F (MaterialStateTest, EqualityOperatorFalseForDifferentShader) {
 
 TEST_F (MaterialStateTest, EqualityOperatorFalseForDifferentPrimitiveType) {
 	MaterialState other = base_state;
-	other.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLESTRIP;
+	other.primitive_type = PrimitiveType::TriangleStrip;
 
 	EXPECT_FALSE (base_state == other);
 }
 
 TEST_F (MaterialStateTest, EqualityOperatorFalseForDifferentCullMode) {
 	MaterialState other = base_state;
-	other.cull_mode = SDL_GPU_CULLMODE_NONE;
+	other.cull_mode = CullMode::None;
 
 	EXPECT_FALSE (base_state == other);
 }
@@ -84,7 +84,7 @@ TEST_F (MaterialStateTest, DifferentPrimitiveTypeProducesDifferentHash) {
 	constexpr std::hash<MaterialState> hasher;
 
 	MaterialState other = base_state;
-	other.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLESTRIP;
+	other.primitive_type = PrimitiveType::TriangleStrip;
 
 	EXPECT_NE (hasher (base_state), hasher (other));
 }
@@ -93,7 +93,7 @@ TEST_F (MaterialStateTest, DifferentCullModeProducesDifferentHash) {
 	constexpr std::hash<MaterialState> hasher;
 
 	MaterialState other = base_state;
-	other.cull_mode = SDL_GPU_CULLMODE_NONE;
+	other.cull_mode = CullMode::None;
 
 	EXPECT_NE (hasher (base_state), hasher (other));
 }
@@ -103,11 +103,11 @@ TEST_F (MaterialStateTest, CompareOpIgnoredWhenDepthTestDisabled) {
 
 	MaterialState a = base_state;
 	a.enable_depth_test = false;
-	a.compare_op = SDL_GPU_COMPAREOP_LESS;
+	a.compare_op = CompareOp::Less;
 
 	MaterialState b = base_state;
 	b.enable_depth_test = false;
-	b.compare_op = SDL_GPU_COMPAREOP_GREATER;
+	b.compare_op = CompareOp::Greater;
 
 	EXPECT_EQ (hasher (a), hasher (b));
 	EXPECT_TRUE (a == b);
@@ -117,10 +117,10 @@ TEST_F (MaterialStateTest, CompareOpAffectsHashWhenDepthTestEnabled) {
 	constexpr std::hash<MaterialState> hasher;
 
 	MaterialState a = base_state;
-	a.compare_op = SDL_GPU_COMPAREOP_LESS;
+	a.compare_op = CompareOp::Less;
 
 	MaterialState b = base_state;
-	b.compare_op = SDL_GPU_COMPAREOP_GREATER;
+	b.compare_op = CompareOp::Greater;
 
 	EXPECT_NE (hasher (a), hasher (b));
 	EXPECT_FALSE (a == b);

--- a/tests/engine/render/test_pass.cpp
+++ b/tests/engine/render/test_pass.cpp
@@ -8,12 +8,10 @@ class RenderPassStateTest : public ::testing::Test {
 
 	void SetUp () override {
 		base_state = {
-			.depth_compare = SDL_GPU_COMPAREOP_LESS,
-			.depth_format = SDL_GPU_TEXTUREFORMAT_D32_FLOAT,
-			.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D32_FLOAT,
-			.color_formats
-			= {SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM,
-			   SDL_GPU_TEXTUREFORMAT_R16G16B16A16_FLOAT},
+			.depth_compare = CompareOp::Less,
+			.depth_format = TextureFormat::D32F,
+			.depth_stencil_format = TextureFormat::D32F,
+			.color_formats = {TextureFormat::BGRA8, TextureFormat::RGBA16F},
 			.has_depth_stencil_target = true
 		};
 	}
@@ -26,14 +24,14 @@ TEST_F (RenderPassStateTest, EqualityOperatorTrueForSameState) {
 
 TEST_F (RenderPassStateTest, EqualityOperatorFalseForDifferentDepthFormat) {
 	RenderPassState other = base_state;
-	other.depth_format = SDL_GPU_TEXTUREFORMAT_D24_UNORM_S8_UINT;
+	other.depth_format = TextureFormat::BGRA8;
 
 	EXPECT_FALSE (base_state == other);
 }
 
 TEST_F (RenderPassStateTest, EqualityOperatorFalseForDifferentColorFormats) {
 	RenderPassState other = base_state;
-	other.color_formats.push_back (SDL_GPU_TEXTUREFORMAT_R8G8B8A8_UNORM);
+	other.color_formats.push_back (TextureFormat::RGBA8);
 
 	EXPECT_FALSE (base_state == other);
 }

--- a/tests/engine/render/test_pipelines.cpp
+++ b/tests/engine/render/test_pipelines.cpp
@@ -31,19 +31,19 @@ class PipelineManagerTest : public ::testing::Test {
 
 	void SetUp () override {
 		render_pass_state = {
-			.depth_compare = SDL_GPU_COMPAREOP_LESS,
-			.depth_format = SDL_GPU_TEXTUREFORMAT_D32_FLOAT,
-			.depth_stencil_format = SDL_GPU_TEXTUREFORMAT_D32_FLOAT,
-			.color_formats = {SDL_GPU_TEXTUREFORMAT_B8G8R8A8_UNORM},
+			.depth_compare = CompareOp::Less,
+			.depth_format = TextureFormat::D32F,
+			.depth_stencil_format = TextureFormat::D32F,
+			.color_formats = {TextureFormat::BGRA8},
 			.has_depth_stencil_target = false
 		};
 
 		material_state = {
 			.vertex_shader = "vertex_shader",
 			.fragment_shader = "fragment_shader",
-			.primitive_type = SDL_GPU_PRIMITIVETYPE_TRIANGLELIST,
-			.cull_mode = SDL_GPU_CULLMODE_BACK,
-			.compare_op = SDL_GPU_COMPAREOP_LESS,
+			.primitive_type = PrimitiveType::TriangleList,
+			.cull_mode = CullMode::Back,
+			.compare_op = CompareOp::Less,
 			.enable_depth_test = true,
 			.enable_depth_write = true
 		};


### PR DESCRIPTION
## Summary
<!-- What does this PR change at a high level? -->
Updating the render graph passes to no longer be exposed to graphical backends by introducing internal types.

## Motivation
<!-- Why is this change needed? What problem does it solve? -->
We need to decouple everything from the graphical backend SDL, which served as the initial layer for GPU rendering. The engine is maturing and now needs a good core module.

## Key changes
<!-- Bullet list of the most important changes -->
- Defined types in the core module which abstract SDL types.
- Removed SDL types from `RenderPassState`.
- Moved `Handle` resolving for resources to `FrameManager`.

## Architectural notes (if applicable)
<!-- Any ownership changes, invariants, or mental-model shifts -->
`RenderPassInstance` no longer needs to resolve textures or be aware of the registry and any graphical backend.

## Follow-ups
<!-- Things intentionally left out or planned next steps -->
- Swap-chain and depth buffer textures are not in the registry yet, they should be owned there.

## Checklist
- [x] Builds and runs locally
- [x] No new warnings
- [x] Naming and ownership make sense
- [x] Has tests